### PR TITLE
fix: bump cadd script version to 1.6.1 (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python via conda.
-        uses: s-weigand/setup-conda@v1
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          conda-channels: defaults,bioconda,conda-forge
-      - name: Install mamba.
-        run: conda install -y mamba
+          miniforge-version: latest
       - name: Install the cadd-scripts package from bioconda
-        run: mamba install -y cadd-scripts
+        run: conda install -c bioconda -y cadd-scripts==1.6.1
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -53,13 +53,12 @@ RUN chmod +x /usr/local/bin/wait
 
 # Install conda environment with varfish-server-worker if configured to do so.
 RUN ["/bin/bash","-c", "cd /tmp && \
-        wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
-        bash Mambaforge-Linux-x86_64.sh -b -p /opt/miniconda3 && \
-        source /opt/miniconda3/bin/activate && \
-        conda install -c conda-forge -y mamba && \
-        mamba install -c conda-forge -c bioconda -y \
-            cadd-scripts==1.6.post1 && \
-        rm -f Mambaforge-Linux-x86_64.sh"]
+        wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+        bash Miniforge3-Linux-x86_64.sh -b -p /opt/miniforge3 && \
+        source /opt/miniforge3/bin/activate && \
+        conda install -c conda-forge -c bioconda -y \
+            cadd-scripts==1.6.1 && \
+        rm -f Miniforge3-Linux-x86_64.sh"]
 
 COPY --from=deps /usr/src/app/.venv /usr/src/app/.venv
 


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `cadd-scripts` package version to `1.6.1` in the CI workflow and Dockerfile to ensure consistent dependency resolution.
	- Changed the Conda setup process to streamline the installation and improve efficiency.
	- Maintained existing configurations for the application setup process, ensuring stability in the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->